### PR TITLE
Fix auto mode chat command

### DIFF
--- a/MainView.cs
+++ b/MainView.cs
@@ -133,7 +133,7 @@ namespace TreeStats
             }
             else
             {
-                Settings.SetAutoMode(false); ;
+                Settings.SetAutoMode(false);
                 Settings.Save();
             }
         }

--- a/Settings.cs
+++ b/Settings.cs
@@ -287,11 +287,11 @@ namespace TreeStats
             {
                 if (autoMode == true)
                 {
-                    SetAutoMode(true);
+                    SetAutoMode(false);
                 }
                 else
                 {
-                    SetAutoMode(false);
+                    SetAutoMode(true);
                 }
             }
             catch (Exception ex)


### PR DESCRIPTION
There are two ways to change auto upload setting. By chat command and by UI checkbox. The UI checkbox is correct, but I believe the chat command has a bug.

`Settings.ToggleMode()` is a method invoked by (and only by) the chat command `/treestats mode`. See only one reference: [here](https://github.com/amoeba/treestats/search?q=Togglemode)
https://github.com/amoeba/treestats/blob/0e0a2a46e8e8333e8b7bee319926b82b4c97726e/PluginCore.cs#L175-L179

The current implementation of `Settings.ToggleMode()` appears to be a no-op. The unexpected behavior is that the chat command doesn't change the setting.
https://github.com/amoeba/treestats/blob/0e0a2a46e8e8333e8b7bee319926b82b4c97726e/Settings.cs#L284-L301

The toggle via UI appears to be correctly tracking the checkbox UI state.
https://github.com/amoeba/treestats/blob/0e0a2a46e8e8333e8b7bee319926b82b4c97726e/MainView.cs#L127-L139

