### PR TITLE
Character location and opt-in setting

### DIFF
--- a/Character.cs
+++ b/Character.cs
@@ -317,6 +317,12 @@ namespace TreeStats
                 req.AppendFormat("\"total_xp\":{0},", cf.TotalXP);
                 req.AppendFormat("\"unassigned_xp\":{0},", cf.UnassignedXP);
                 req.AppendFormat("\"skill_credits\":{0},", cf.SkillPoints);
+
+                if (Settings.sendLocation)
+                {
+                    req.AppendFormat("\"location\":{0},", GetLocation());  
+                }
+
                 //req.AppendFormat("\"age\":{0},", cf.Age);
 
                 // Luminance XP
@@ -754,6 +760,20 @@ namespace TreeStats
             {
                 Logging.LogError(ex);
             }
+        }
+
+        internal static string GetLocation()
+        {
+            Decal.Adapter.Wrappers.CharacterFilter cf = MyCore.CharacterFilter;
+            var coords = MyCore.WorldFilter.GetByName(cf.Name).First.Coordinates();
+
+            if ( coords == null ) // Indoors?
+                return "";
+
+            string northSouth = $"{Math.Abs(coords.NorthSouth).ToString("F2")}{(coords.NorthSouth >= 0 ? "N" : "S")}";
+            string eastWest = $"{Math.Abs(coords.EastWest).ToString("F2")}{(coords.EastWest >= 0 ? "E" : "W")}";
+                    
+            return $"{northSouth},{eastWest}";
         }
     }
 }

--- a/MainView.cs
+++ b/MainView.cs
@@ -9,6 +9,7 @@ namespace TreeStats
         static MyClasses.MetaViewWrappers.IView View;
         static MyClasses.MetaViewWrappers.IButton btnSendUpdate;
         static MyClasses.MetaViewWrappers.ICheckBox chkAutoMode;
+        static MyClasses.MetaViewWrappers.ICheckBox chkSendLocation;
         static MyClasses.MetaViewWrappers.IButton btnAddCharacter;
         static MyClasses.MetaViewWrappers.IButton btnRemoveCharacter;
 
@@ -39,6 +40,9 @@ namespace TreeStats
 
             chkAutoMode = (MyClasses.MetaViewWrappers.ICheckBox)View["chkAutoMode"];
             chkAutoMode.Change += new EventHandler<MyClasses.MetaViewWrappers.MVCheckBoxChangeEventArgs>(chkAutoMode_Change);
+
+            chkSendLocation = (MyClasses.MetaViewWrappers.ICheckBox)View["chkSendLocation"];
+            chkSendLocation.Change += new EventHandler<MyClasses.MetaViewWrappers.MVCheckBoxChangeEventArgs>(chkSendLocation_Change);
 
             btnAddCharacter = (MyClasses.MetaViewWrappers.IButton)View["btnAddCharacter"];
             btnAddCharacter.Hit += new EventHandler(btnAddCharacter_Hit);
@@ -72,6 +76,11 @@ namespace TreeStats
             if (Settings.autoMode == true)
             {
                 chkAutoMode.Checked = true;
+            }
+
+            if (Settings.sendLocation == true)
+            {
+                chkSendLocation.Checked = true;
             }
 
             if (Settings.useAccount == true)
@@ -109,6 +118,7 @@ namespace TreeStats
         {
             btnSendUpdate = null;
             chkAutoMode = null;
+            chkSendLocation = null;
             btnAddCharacter = null;
             btnRemoveCharacter = null;
             btnSendUpdate = null;
@@ -134,6 +144,20 @@ namespace TreeStats
             else
             {
                 Settings.SetAutoMode(false); ;
+                Settings.Save();
+            }
+        }
+
+        static void chkSendLocation_Change(object sender, MyClasses.MetaViewWrappers.MVCheckBoxChangeEventArgs e)
+        {
+            if (e.Checked)
+            {
+                Settings.SetSendLocation(true);
+                Settings.Save();
+            }
+            else
+            {
+                Settings.SetSendLocation(false); ;
                 Settings.Save();
             }
         }

--- a/MainView.xml
+++ b/MainView.xml
@@ -5,6 +5,7 @@
       <page label="Update">
         <control progid="DecalControls.FixedLayout" clipped="">
           <control progid="DecalControls.CheckBox" name="chkAutoMode" left="10" top="10" width="180" height="25" text="Auto. Send All Characters" checked="false"/>
+          <control progid="DecalControls.CheckBox" name="chkSendLocation" left="10" top="10" width="180" height="25" text="Send Location" checked="false"/>
           <control progid="DecalControls.PushButton" name="btnSendUpdate" left="10" top="30" width="160" height="25" text="Manually Send Character" />
           <control progid="DecalControls.StaticText" name="txtWhitelist" left="10" top="70" width="180" height="25" text="Whitelist (Always Send):" />
           <control progid="DecalControls.PushButton" name="btnAddCharacter" left="10" top="90" width="120" height="25" text="Add Character" />

--- a/PluginCore.cs
+++ b/PluginCore.cs
@@ -177,6 +177,11 @@ namespace TreeStats
                             Settings.ToggleMode();
                             Settings.Save();
                         }
+                        else if (command == "loc")
+                        {
+                            Settings.ToggleLocation();
+                            Settings.Save();
+                        }
                         else if (command == "add")
                         {
                             Settings.AddCharacter(Core.CharacterFilter.Server + "-" + Core.CharacterFilter.Name);

--- a/Settings.cs
+++ b/Settings.cs
@@ -15,6 +15,7 @@ namespace TreeStats
 
         // Tracked settings
         public static bool autoMode;
+        public static bool sendLocation;
         public static List<string> trackedCharacters;
         public static bool useAccount;
         public static string accountName;
@@ -31,6 +32,7 @@ namespace TreeStats
                 settingsFile = _settingsFileName;
 
                 autoMode = false;
+                sendLocation = false;
                 trackedCharacters = new List<string>();
                 useAccount = false;
                 accountName = "";
@@ -73,6 +75,9 @@ namespace TreeStats
 
                 // Write auto mode
                 sw.WriteLine("auto:" + autoMode.ToString());
+
+                // Write send location
+                sw.WriteLine("loc:" + sendLocation.ToString());
 
                 // Write account info if present
                 sw.WriteLine("use_account:" + useAccount.ToString());
@@ -149,6 +154,20 @@ namespace TreeStats
                             else if (tokens[1] == "False")
                             {
                                 autoMode = false;
+                            }
+
+                            break;
+                        case "loc": // Send location setting, True | False
+                            Logging.LogMessage("Reading location setting with stored value of " + tokens[1]);
+
+                            // Try to grab token[1] as a bool
+                            if (tokens[1] == "True")
+                            {
+                                sendLocation = true;
+                            }
+                            else if (tokens[1] == "False")
+                            {
+                                sendLocation = false;
                             }
 
                             break;
@@ -281,6 +300,27 @@ namespace TreeStats
             }
         }
 
+        internal static void SetSendLocation(bool state)
+        {
+            try
+            {
+                if (state == true)
+                {
+                    Util.WriteToChat("Setting location to visible. Character location will be uploaded.");
+                    sendLocation = true;
+                }
+                else
+                {
+                    Util.WriteToChat("Setting location to hidden. Character location will not be uploaded.");
+                    sendLocation = false;
+                }
+            }
+            catch (Exception ex)
+            {
+                Logging.LogError(ex);
+            }
+        }
+
         internal static void ToggleMode()
         {
             try
@@ -292,6 +332,25 @@ namespace TreeStats
                 else
                 {
                     SetAutoMode(false);
+                }
+            }
+            catch (Exception ex)
+            {
+                Logging.LogError(ex);
+            }
+        }
+
+        internal static void ToggleLocation()
+        {
+            try
+            {
+                if (sendLocation == true)
+                {
+                    SetSendLocation(false);
+                }
+                else
+                {
+                    SetSendLocation(true);
                 }
             }
             catch (Exception ex)
@@ -368,6 +427,7 @@ namespace TreeStats
                 Util.WriteToChat("mode: Toggle mode between automatic and manual tracking.");
                 Util.WriteToChat("     auto: Automatically upload characters.");
                 Util.WriteToChat("     manual: Only upload characters you manually add. See add/rem.");
+                Util.WriteToChat("loc: Toggle between sending or not sending character location.");
                 Util.WriteToChat("add: Enables tracking for the currently logged in character.");
                 Util.WriteToChat("rem: Removes tracking for the currently logged in character.");
                 Util.WriteToChat("account: Create or log into an account.");


### PR DESCRIPTION
Issue: https://github.com/amoeba/treestats/issues/36
Treestats.net PR: https://github.com/amoeba/treestats.net/pull/213

- Chat command `/treestats loc` to toggle location sending
- Help output line for new command
- UI checkbox to toggle location setting
- Fetching and sending character location data to treestats.net

### References 
`StatsDump` plugin has an example of getting location/coordinate data: [here](https://github.com/OptimShi/StatsDump/blob/36ed8d8a6e7573285bcc84c20f2da74733528575/PluginCore.cs#L434-L437)
`UtilityBelt` plugin has an example of formatting into the familiar string: [here](https://gitlab.com/utilitybelt/utilitybelt.gitlab.io/-/blob/master/UtilityBelt/Lib/Coordinate.cs#L66-69) also an example of `NorthSouth` and `EastWest` properties invoked off of the world object: [here](https://gitlab.com/utilitybelt/utilitybelt.gitlab.io/-/blob/master/UtilityBelt/Lib/VTNav/Waypoints/VTNOpenVendor.cs#L69-71)

### Disclaimer
Currently don't have a workflow to fully test. Could use some help there.

